### PR TITLE
Keep anchors linked to post page

### DIFF
--- a/content/keras-as-a-simplified-interface-to-tensorflow-tutorial.md
+++ b/content/keras-as-a-simplified-interface-to-tensorflow-tutorial.md
@@ -13,13 +13,13 @@ Keras layers and models are fully compatible with pure-TensorFlow tensors, and a
 
 We will cover the following points:
 
-[I: Calling Keras layers on TensorFlow tensors](/#calling-keras-layers-on-tensorflow-tensors)
+[I: Calling Keras layers on TensorFlow tensors](#calling-keras-layers-on-tensorflow-tensors)
 
-[II: Using Keras models with TensorFlow](/#using-keras-models-with-tensorflow)
+[II: Using Keras models with TensorFlow](#using-keras-models-with-tensorflow)
 
-[III: Multi-GPU and distributed training](/#multi-gpu-and-distributed-training)
+[III: Multi-GPU and distributed training](#multi-gpu-and-distributed-training)
 
-[IV: Exporting a model with TensorFlow-serving](/#exporting-a-model-with-tensorflow-serving)
+[IV: Exporting a model with TensorFlow-serving](#exporting-a-model-with-tensorflow-serving)
 
 
 ![keras+tensorflow](/img/keras-tensorflow-logo.jpg)


### PR DESCRIPTION
Remove leading '/' to prevent anchors from redirecting to root