### PR TITLE
Add feeds/all.atom.xml to feed url

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
         <link rel="stylesheet" href="http://blog.keras.io/theme/css/pygment.css" type="text/css" />
 
         <link href="https://fonts.googleapis.com/css?family=Lato:400,700|Source+Sans+Pro:400,700|Inconsolata:400,700" rel="stylesheet" type="text/css">
-        <link href="http://blog.keras.io/" type="application/atom+xml" rel="alternate" title="The Keras Blog ATOM Feed" />
+        <link href="http://blog.keras.io/feeds/all.atom.xml" type="application/atom+xml" rel="alternate" title="The Keras Blog ATOM Feed" />
 
 
         <!--[if IE]>


### PR DESCRIPTION
Reeder by default doesn't recognize the feed url.